### PR TITLE
allow user to switch off high-resolution datasets

### DIFF
--- a/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/Activator.java
+++ b/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/Activator.java
@@ -229,7 +229,7 @@ public class Activator extends AbstractUIPlugin
 //			ne10.add(createF(null, "ne_10m_ports", true, null, null, Color.pink, 8,
 //					0, "Times"));
 
-			NEFeatureGroup ne50 = new NEResolution("50M", 3000000d, 30000000d);
+			NEFeatureGroup ne50 = new NEResolution("50M", null, 30000000d);
 			ne50.add(bathy);
 
 			ne50.add(createF(null, "ne_50m_ocean", true, new Color(165, 191, 221),
@@ -248,7 +248,7 @@ public class Activator extends AbstractUIPlugin
 					67, 98), 20, ITALIC | BOLD, "Serif"));
 
 			// NEFeatureGroup ne110 = new NEResolution("110M", null, null);
- 		  NEFeatureGroup ne110 = new NEResolution("110M", 30000000d, null);
+ 		  NEFeatureGroup ne110 = new NEResolution("110M", null, null);
 			ne110.add(createF(null, "ne_110m_land", true, new Color(235, 219, 188),
 					new Color(162, 162, 162)));
 			ne110.add(createF(null, "ne_110m_ocean", true, new Color(165, 191, 221),

--- a/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/view/NEFeatureStore.java
+++ b/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/view/NEFeatureStore.java
@@ -21,9 +21,12 @@ public class NEFeatureStore extends Plottables
 		while (iter.hasMoreElements())
 		{
 			NEResolution thisR = (NEResolution) iter.nextElement();
-			if(thisR.canPlot(scale))
+			if(thisR.getVisible())
 			{
-				return thisR;
+				if(thisR.canPlot(scale))
+				{
+					return thisR;
+				}
 			}
 		}
 		

--- a/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/view/NEResolution.java
+++ b/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/view/NEResolution.java
@@ -1,10 +1,6 @@
 package org.mwc.cmap.naturalearth.view;
 
 import MWC.GUI.Plottable;
-import MWC.TacticalData.NarrativeEntry;
-
-
-
 
 public class NEResolution extends NEFeatureGroup
 {
@@ -70,7 +66,7 @@ public class NEResolution extends NEFeatureGroup
 	}
 
 	/**
-	 * member function to meet requirements of comparable interface *
+	 * Sort the resolution objects by scale (to prevent them being sorted by name)
 	 */
 	public final int compareTo(final Plottable o)
 	{

--- a/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/view/NEResolution.java
+++ b/org.mwc.cmap.NaturalEarth/src/org/mwc/cmap/naturalearth/view/NEResolution.java
@@ -1,5 +1,8 @@
 package org.mwc.cmap.naturalearth.view;
 
+import MWC.GUI.Plottable;
+import MWC.TacticalData.NarrativeEntry;
+
 
 
 
@@ -65,6 +68,37 @@ public class NEResolution extends NEFeatureGroup
 	{
 		_activeRes = b;
 	}
-	
+
+	/**
+	 * member function to meet requirements of comparable interface *
+	 */
+	public final int compareTo(final Plottable o)
+	{
+		final int res;
+		
+		final NEResolution other = (NEResolution) o;
+		
+		// do we have a max value?
+		if(_maxS == null)
+		{
+			// nope, so we're the fallback method - make us last
+			res = 1;
+		}
+		else
+		{
+			// does he have a max value?
+			if(other._maxS == null)
+			{
+				// he's the fallback method, make him last
+				res = -1;
+			}
+			else
+			{
+				res = _maxS.compareTo(other._maxS);
+			}
+		}
+		
+		return res;
+	}	
 	
 }


### PR DESCRIPTION
allow user to switch off high-resolution datasets, so Debrief shows background more quickly.

This is a stepping stone to when Debrief can handle only some resolutions being present.